### PR TITLE
fix: fallback to default auth plugin if not set

### DIFF
--- a/proto/auth.go
+++ b/proto/auth.go
@@ -113,9 +113,12 @@ func (a *Auth) UnPack(payload []byte) error {
 		if a.pluginName, err = buf.ReadStringNUL(); err != nil {
 			return fmt.Errorf("auth.unpack: can't read pluginName")
 		}
-	}
-	if a.pluginName != DefaultAuthPluginName {
-		return fmt.Errorf("invalid authPluginName, got %v but only support %v", a.pluginName, DefaultAuthPluginName)
+		if a.pluginName != DefaultAuthPluginName {
+			return fmt.Errorf("invalid authPluginName, got '%s' but only support %s", a.pluginName, DefaultAuthPluginName)
+		}
+	} else {
+		// Allow fallback to default auth plugin
+		a.pluginName = DefaultAuthPluginName
 	}
 	return nil
 }

--- a/proto/auth_test.go
+++ b/proto/auth_test.go
@@ -198,6 +198,28 @@ func TestAuthWithoutSecure(t *testing.T) {
 	assert.Equal(t, want, got)
 }
 
+func TestAuthWithoutPluginAuth(t *testing.T) {
+	want := NewAuth()
+	want.charset = 0x02
+	want.authResponseLen = 20
+	want.clientFlags = DefaultClientCapability ^ sqldb.CLIENT_PLUGIN_AUTH
+	want.authResponse = nativePassword("sbtest", DefaultSalt)
+	want.user = "sbtest"
+	want.database = "test_db"
+
+	got := NewAuth()
+	err := got.UnPack(want.Pack(
+		DefaultClientCapability,
+		0x02,
+		"sbtest",
+		"sbtest",
+		DefaultSalt,
+		"",
+	))
+	assert.Nil(t, err)
+	assert.Equal(t, got.pluginName, DefaultAuthPluginName)
+}
+
 func TestAuthUnPackError(t *testing.T) {
 	capabilityFlags := DefaultClientCapability
 	capabilityFlags |= sqldb.CLIENT_PROTOCOL_41


### PR DESCRIPTION
Some MySQL clients don't specify auth plugin capability during the handshake ([for example](https://github.com/mysqljs/mysql/blob/dc04c61c2bcb0da4e925cd814763e5e09b971909/lib/ConnectionConfig.js#L36-L40
)). These clients are able to connect to MySQL 5.7 server, but not to go-mysqlstack.

I think the change in this PR replicates [MySQL 5.7 logic](https://github.com/mysql/mysql-server/blob/5.7/sql/auth/sql_authentication.cc#L1110-L1121) which sets client auth plugin to `mysql_native_password` when client auth capability is not specified in handshake.

Thanks for the great project!