### PR TITLE
Fix build for Windows

### DIFF
--- a/xlog/syslog.go
+++ b/xlog/syslog.go
@@ -1,0 +1,14 @@
+// +build linux darwin dragonfly freebsd netbsd openbsd solaris
+
+package xlog
+
+import "log/syslog"
+
+// NewSysLog creates a new sys log.
+func NewSysLog(opts ...Option) *Log {
+	w, err := syslog.New(syslog.LOG_DEBUG, "")
+	if err != nil {
+		panic(err)
+	}
+	return NewXLog(w, opts...)
+}

--- a/xlog/syslog_windows.go
+++ b/xlog/syslog_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package xlog
+
+import (
+	"os"
+)
+
+// NewSysLog creates a new sys log. Because there is no syslog support for
+// Windows, we output to os.Stdout.
+func NewSysLog(opts ...Option) *Log {
+	return NewXLog(os.Stdout, opts...)
+}

--- a/xlog/xlog.go
+++ b/xlog/xlog.go
@@ -13,7 +13,6 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"log/syslog"
 	"os"
 	"strings"
 )
@@ -59,15 +58,6 @@ const (
 type Log struct {
 	opts *Options
 	*log.Logger
-}
-
-// NewSysLog creates a new sys log.
-func NewSysLog(opts ...Option) *Log {
-	w, err := syslog.New(syslog.LOG_DEBUG, "")
-	if err != nil {
-		panic(err)
-	}
-	return NewXLog(w, opts...)
 }
 
 // NewStdLog creates a new std log.


### PR DESCRIPTION
This PR fixes the package so it can be imported when used under Windows.
The `syslog` package unfortunately is not supported under Windows. Hence
we disable it if we detect it.

Fixes the following error:

```
xlog.go:66:12: undefined: syslog.New
xlog.go:66:23: undefined: syslog.LOG_DEBUG
```